### PR TITLE
Fixed warnings about default field value

### DIFF
--- a/mlnserver/settings.py
+++ b/mlnserver/settings.py
@@ -84,6 +84,7 @@ DATABASES = {
 	}
 }
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
Every `manage.py` command outputs 100 lines of warnings saying to add this line. 