### PR TITLE
Fix bugs when editing modules

### DIFF
--- a/mln/models/module.py
+++ b/mln/models/module.py
@@ -29,9 +29,7 @@ class Module(models.Model):
 		constraints = (models.UniqueConstraint(fields=("owner", "pos_x", "pos_y"), name="module_unique_owner_pos"),)
 
 	def __str__(self):
-		if self.pos_x is None or self.pos_y is None:
-			return "%s's %s, %i clicks" % (self.owner, self.item.name, self.total_clicks)
-		return "%s's %s at pos (%i, %i), %i clicks" % (self.owner, self.item.name, self.pos_x, self.pos_y, self.total_clicks)
+		return "%s's %s at pos (%s, %s), %i clicks" % (self.owner, self.item.name, self.pos_x, self.pos_y, self.total_clicks)
 
 	def get_info(self):
 		"""Get the ModuleInfo for this module."""

--- a/mln/models/module.py
+++ b/mln/models/module.py
@@ -29,6 +29,8 @@ class Module(models.Model):
 		constraints = (models.UniqueConstraint(fields=("owner", "pos_x", "pos_y"), name="module_unique_owner_pos"),)
 
 	def __str__(self):
+		if self.pos_x is None or self.pos_y is None:
+			return "%s's %s, %i clicks" % (self.owner, self.item.name, self.total_clicks)
 		return "%s's %s at pos (%i, %i), %i clicks" % (self.owner, self.item.name, self.pos_x, self.pos_y, self.total_clicks)
 
 	def get_info(self):

--- a/mln/services/inventory.py
+++ b/mln/services/inventory.py
@@ -36,10 +36,11 @@ def remove_inv_item(user, item_id, qty=1):
 	else:
 		raise RuntimeError("%s has fewer items than the %i requested to delete" % (stack, qty))
 
-def return_invalid_modules(user): 
-	for module in user.modules.filter(Q(pos_x__isnull=True) | Q(pos_y__isnull=True)): 
+def refund_invalid_modules(user): 
+	corrupt_modules = user.modules.filter(Q(pos_x__isnull=True) | Q(pos_y__isnull=True))
+	for module in corrupt_modules: 
 		add_inv_item(user, module.item_id)
-		module.delete()
+	corrupt_modules.delete()
 
 def assert_has_item(user, item_id, qty=1, field_name=None):
 	"""

--- a/mln/services/inventory.py
+++ b/mln/services/inventory.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db.models import Q
 
 from ..models.static import ItemInfo
 
@@ -35,6 +36,10 @@ def remove_inv_item(user, item_id, qty=1):
 	else:
 		raise RuntimeError("%s has fewer items than the %i requested to delete" % (stack, qty))
 
+def return_invalid_modules(user): 
+	for module in user.modules.filter(Q(pos_x__isnull=True) | Q(pos_y__isnull=True)): 
+		add_inv_item(user, module.item_id)
+		module.delete()
 
 def assert_has_item(user, item_id, qty=1, field_name=None):
 	"""

--- a/mln/services/module_settings.py
+++ b/mln/services/module_settings.py
@@ -1,3 +1,4 @@
+from .inventory import remove_inv_item
 
 def create_or_update(cls, module, attrs):
 	save_obj, created = cls.objects.get_or_create(module=module, defaults=attrs)
@@ -9,4 +10,5 @@ def create_or_update(cls, module, attrs):
 def get_or_create_module(user, instance_id, item_id):
 	if instance_id is not None:
 		return user.modules.get(id=instance_id)
+	remove_inv_item(user, item_id)
 	return user.modules.create(item_id=item_id)

--- a/mln/templates/mln/api/xml/page/write_page_modules.xml
+++ b/mln/templates/mln/api/xml/page/write_page_modules.xml
@@ -1,5 +1,5 @@
 {% load mln_utils %}
-{% for module in page_owner.modules.all %}
+{% for module in page_owner|get_valid_modules %}
 	<item type="module" itemID="{{ module.item_id }}" instanceID="{{ module.id }}"
 		{% if module.is_setup %}
 		isSetup="True"

--- a/mln/templatetags/mln_utils.py
+++ b/mln/templatetags/mln_utils.py
@@ -156,6 +156,10 @@ def replyable(message):
 	else:
 		return MessageReplyType.NORMAL_REPLY_ONLY.value
 
+@register.filter
+def get_valid_modules(owner): 
+	return owner.modules.filter(pos_x__isnull=False, pos_y__isnull=False)
+
 # Fix for Django template compilation, to remove whitespace from templates.
 # The two tokenize functions are changed to avoid generating a TextNode when the text content is only whitespace.
 # The TextNode constructor is changed to remove as much whitespace as possible from the content.

--- a/mln/views/ui.py
+++ b/mln/views/ui.py
@@ -8,12 +8,12 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 
-from ..services.inventory import return_invalid_modules
+from ..services.inventory import refund_invalid_modules
 
 @login_required
 def private_view(request):
 	"""MLN's private view. Only available for logged in users."""
-	return_invalid_modules(request.user)
+	refund_invalid_modules(request.user)
 	return render(request, "mln/ui/private_view.html")
 
 def public_view(request, page_owner_name):

--- a/mln/views/ui.py
+++ b/mln/views/ui.py
@@ -8,9 +8,12 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 
+from ..services.inventory import return_invalid_modules
+
 @login_required
 def private_view(request):
 	"""MLN's private view. Only available for logged in users."""
+	return_invalid_modules(request.user)
 	return render(request, "mln/ui/private_view.html")
 
 def public_view(request, page_owner_name):


### PR DESCRIPTION
Fixes two bugs: 
- place module, edit module settings, remove module, save page --> duplicate item
- place module, edit module settings --> corrupt page (can be fixed by re-arranging)

These bugs are caused by the fact that editing a module's settings will create the module if it hasn't already been. The first bug is fixed by removing the duplicate item when saving the settings. The second bug is fixed by scanning for corrupt modules (where the coordinates on the user's page are null) when the user signs in and removing them (since they weren't saved) and refunding them to the user's inventory. It also hides these corrupt modules from the public page until they are properly removed. 