### PR TITLE
Import Module Click Outcome For Existing Modules

### DIFF
--- a/mln/management/commands/import_mln_xml.py
+++ b/mln/management/commands/import_mln_xml.py
@@ -210,4 +210,11 @@ class Command(BaseCommand):
 		for key, value in t.items():
 			key.objects.bulk_create(value, ignore_conflicts=True)
 
+		# Pull request 23/25 added a click outcome column. It must be populated in existing modules for votes to work.
+		for module_outcome in ModuleInfo.objects.filter(click_outcome=None):
+			for item_info in xml.findall("items/item"):
+				if str(module_outcome.item_id) == item_info.get("id"):
+					module_outcome.click_outcome = self.get_module_click_outcome(item_info)
+					module_outcome.save()
+
 		print("Import successful.")

--- a/mln/management/commands/import_mln_xml.py
+++ b/mln/management/commands/import_mln_xml.py
@@ -42,24 +42,24 @@ class Command(BaseCommand):
 		is_executable = item_info.get("isExecutable") == "True"
 		yield_elem = item_info.find("yield")
 
-		clickOutcome = ModuleOutcome.NUM_CLICKS
+		click_outcome = ModuleOutcome.NUM_CLICKS
 		if is_executable and (yield_elem is None or int(item_info.find("yield").get("voteAmount")) <= 1):
-			clickOutcome = ModuleOutcome.PROBABILITY
+			click_outcome = ModuleOutcome.PROBABILITY
 		if yield_elem is not None:
 			if len(yield_elem.findall("guestCost/items")) > 0 and yield_elem.findall("guestCost/items")[0].get("itemID") == "72401":
-				clickOutcome = ModuleOutcome.ARCADE
+				click_outcome = ModuleOutcome.ARCADE
 			elif len(yield_elem.findall("guestCost/items")) > 0 and len(yield_elem.findall("ownerLaunchCost/items")) > 0:
-				yieldDescription = item_info.get("yieldDescription")
-				if "risk" in yieldDescription or "compete" in yieldDescription or "chance" in yieldDescription or "Battle" in yieldDescription:
-					clickOutcome = ModuleOutcome.BATTLE
+				yield_description = item_info.get("yieldDescription")
+				if "risk" in yield_description or "compete" in yield_description or "chance" in yield_description or "Battle" in yield_description:
+					click_outcome = ModuleOutcome.BATTLE
 				else:
-					clickOutcome = ModuleOutcome.NUM_CLICKS
+					click_outcome = ModuleOutcome.NUM_CLICKS
 
 		if id == 50932:
 			# Special case for the Group Performance Module being PROBABILITY instead of NUM_CLICKS, which would lead to double rewards
-			clickOutcome = ModuleOutcome.NUM_CLICKS
+			click_outcome = ModuleOutcome.NUM_CLICKS
 
-		return clickOutcome
+		return click_outcome
 
 	def handle(self, *args, **options):
 		EasyReply = MessageBody.easy_replies.through
@@ -126,8 +126,8 @@ class Command(BaseCommand):
 
 				is_executable = item_info.get("isExecutable") == "True"
 				yield_elem = item_info.find("yield")
-				clickOutcome = self.get_module_click_outcome(item_info)
-				t[ModuleInfo].append(ModuleInfo(item_id=id, is_executable=is_executable, editor_type=editor_type, click_outcome=clickOutcome))
+				click_outcome = self.get_module_click_outcome(item_info)
+				t[ModuleInfo].append(ModuleInfo(item_id=id, is_executable=is_executable, editor_type=editor_type, click_outcome=click_outcome))
 
 				if yield_elem is None: continue
 
@@ -138,7 +138,7 @@ class Command(BaseCommand):
 				max_yield = int(yield_elem.get("maxPerDay"))
 				yield_per_day = int(yield_elem.get("perDay"))
 				clicks_per_yield = int(yield_elem.get("voteAmount"))
-				if clicks_per_yield == 0 and clickOutcome == ModuleOutcome.NUM_CLICKS:
+				if clicks_per_yield == 0 and click_outcome == ModuleOutcome.NUM_CLICKS:
 					# Special case for Transmuting Pools.
 					clicks_per_yield = 1
 				if id == 51622 or id == 51623 or id == 51624 or id == 51625:


### PR DESCRIPTION
Pull requests #23 and #25 included importing module click outcomes for new modules but not existing ones. Existing modules now have a pass to add module click outcomes. This was not done as a migration since it is tied to the XML file(s) that are imported.

In addition, I defaulted to camelCase instead of snake_case for pull request #25. That has been corrected.