### PR TITLE
Add Default Page Redirects

### DIFF
--- a/mln/urls.py
+++ b/mln/urls.py
@@ -11,6 +11,7 @@ from .views import ui
 from .views.api.xml import webservice
 
 urlpatterns = [
+	path("", lambda x: redirect("private_view/default")),
 	path("status.aspx", lambda x: redirect("login")), # login prompt when clicking on page while not logged in
 	path("private_view/default", ui.private_view, name="private_view"),
 	path("PrivateView/Default.aspx", lambda x: redirect("private_view")),

--- a/mlnserver/urls.py
+++ b/mlnserver/urls.py
@@ -6,6 +6,7 @@ In debug mode django's staticfiles server is also registered, in production this
 from django.conf import settings
 from django.contrib import admin
 from django.http import Http404
+from django.shortcuts import redirect
 from django.urls import include, path
 from django.conf.urls.static import static
 from django.contrib.auth.forms import UserCreationForm
@@ -17,6 +18,7 @@ def flashvars_handler(request):
 	Contact the server operator if you did not intend to get here.""")
 
 urlpatterns = [
+	path("", lambda x: redirect("mln/private_view/default")),
 	path("mln/", include("mln.urls")),
 	path("ugc/", include("ugc.urls")),
 	path("ugc", flashvars_handler, name="ugc"),


### PR DESCRIPTION
To reduce user confusion, `/` and `/mln` should redirect to `/mln/private_view/default` instead of giving an HTTP 404 error.