### PR TITLE
Fix Module Message Ids

### DIFF
--- a/mln/migrations/0031_correct_message_templates.py
+++ b/mln/migrations/0031_correct_message_templates.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def replace_message_template_ids(apps, schema_editor):
+    ModuleMessage = apps.get_model("mln", "ModuleMessage")
+    for module_message in ModuleMessage.objects.all():
+        message_template = module_message.message
+        if message_template.body_id == 1:
+            message_template.body_id = module_message.module_item_id
+            message_template.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mln', '0030_alter_messagebody_easy_replies_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(replace_message_template_ids, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
Modules with messages current import with a placeholder message instead the actual message. The id of the message happens to be the id of the module. Changing the import to use these ids makes the correct messages appear for modules that send messages to friends when clicked. Importing had to be tweaked to create messages first, otherwise, constraint violations would appear due to the message body not existing.