### PR TITLE
Fixed bug where you could not remove pending friend request

### DIFF
--- a/mln/services/friend.py
+++ b/mln/services/friend.py
@@ -70,6 +70,9 @@ def handle_friend_invite_response(user, relation_id, accept):
 def remove_friend(user, relation_id):
 	"""
 	Remove a friend from the user's friend list.
+	Raise RuntimeError if
+	- the friendship does not exist
+	- the relation does not relate to this user, or
 	Raise MLNError if the the user is blocked.
 	"""
 	relation = _get_friendship(user, relation_id)

--- a/mln/services/friend.py
+++ b/mln/services/friend.py
@@ -70,15 +70,9 @@ def handle_friend_invite_response(user, relation_id, accept):
 def remove_friend(user, relation_id):
 	"""
 	Remove a friend from the user's friend list.
-	Raise RuntimeError if
-	- the friendship does not exist
-	- the relation does not relate to this user, or
-	- the relation is not a friend or blocked relation.
 	Raise MLNError if the the user is blocked.
 	"""
 	relation = _get_friendship(user, relation_id)
-	if relation.status not in (FriendshipStatus.FRIEND, FriendshipStatus.BLOCKED):
-		raise RuntimeError("%s is not a friend or blocked relation" % relation)
 	if relation.status == FriendshipStatus.BLOCKED and relation.from_user != user:
 		raise MLNError(MLNError.YOU_ARE_BLOCKED)
 	relation.delete()

--- a/mln/services/friend.py
+++ b/mln/services/friend.py
@@ -71,8 +71,8 @@ def remove_friend(user, relation_id):
 	"""
 	Remove a friend from the user's friend list.
 	Raise RuntimeError if
-	- the friendship does not exist
-	- the relation does not relate to this user, or
+	- the friendship does not exist, or
+	- the relation does not relate to this user
 	Raise MLNError if the the user is blocked.
 	"""
 	relation = _get_friendship(user, relation_id)


### PR DESCRIPTION
There was an explicit check for a non-pending friend request in `remove_friend`, but the UI does let you remove pending friend requests (it cancels the request). This PR removes that check to allow users to cancel their pending outgoing requests. 