### PR TITLE
Actually give arcade rewards when the user wins

### DIFF
--- a/mln/models/dynamic/module.py
+++ b/mln/models/dynamic/module.py
@@ -140,7 +140,7 @@ class Module(models.Model):
 
 		# Update information about the module
 		self._update_clicks(clicker)
-		if self.is_setup and self.did_guest_win and outcome not in (ModuleOutcome.NUM_CLICKS, ModuleOutcome.ARCADE):
+		if self.is_setup and self.did_guest_win and outcome != ModuleOutcome.NUM_CLICKS:
 			# Tear down the module if the guest won
 			self.is_setup = False
 			self.save()

--- a/mln/models/dynamic/module.py
+++ b/mln/models/dynamic/module.py
@@ -150,6 +150,12 @@ class Module(models.Model):
 		self.yield_since_last_harvest += qty
 		self.save()
 
+	def grant_arcade_prize(self, clicker):
+		all_prizes = self.item.moduleguestyields.all()
+		prize = self._get_yield(all_prizes)
+		add_inv_item(clicker, prize.item_id, prize.qty)
+		return prize
+
 	def harvest(self):
 		"""
 		Harvest the module.

--- a/mln/models/dynamic/module.py
+++ b/mln/models/dynamic/module.py
@@ -129,8 +129,9 @@ class Module(models.Model):
 			add_inv_item(clicker, trade.give_item.id, trade.give_qty)
 
 		# Handle guest yields separately
+		outcome = self.item.module_info.click_outcome
 		result = None  # we return the guest yield to the UI
-		if (self.item.module_info.click_outcome != ModuleOutcome.ARCADE): 
+		if (outcome != ModuleOutcome.ARCADE): 
 			guest_yield = self._get_yield(self.item.moduleguestyields.all())
 			if guest_yield is not None:
 				guest_yield.on_click(self, clicker)
@@ -139,7 +140,8 @@ class Module(models.Model):
 
 		# Update information about the module
 		self._update_clicks(clicker)
-		if self.is_setup and self.did_guest_win and self.item.module_info.click_outcome != ModuleOutcome.NUM_CLICKS:
+		if self.is_setup and self.did_guest_win and outcome not in (ModuleOutcome.NUM_CLICKS, ModuleOutcome.ARCADE):
+			# Tear down the module if the guest won
 			self.is_setup = False
 			self.save()
 		return result

--- a/mln/models/static/module_handlers.py
+++ b/mln/models/static/module_handlers.py
@@ -82,7 +82,7 @@ class ModuleGuestYield(ModuleClickYield):
 		if outcome == ModuleOutcome.PROBABILITY: return True
 		elif outcome == ModuleOutcome.NUM_CLICKS: return True
 		elif outcome == ModuleOutcome.BATTLE: return module.did_guest_win
-		elif outcome == ModuleOutcome.ARCADE: return module.did_guest_win
+		elif outcome == ModuleOutcome.ARCADE: return False  # reward should be calculated using Module._get_yield
 		else: raise RuntimeError("Unknown module outcome: %s" % outcome)
 
 	def distribute_items(self, module, clicker): 

--- a/mln/views/api/xml/module.py
+++ b/mln/views/api/xml/module.py
@@ -19,8 +19,7 @@ def handle_module_collect_winnings(user, request):
 	won = request.get("won") == "True"
 	# todo: arcade stats
 	if won:
-		all_prizes = module.item.moduleguestyields.all()
-		prize = module._get_yield(all_prizes)
+		prize = module.grant_arcade_prize(user)
 		return {"won": won, "prize": prize}
 	else:
 		return {"won": won}

--- a/mln/views/api/xml/module.py
+++ b/mln/views/api/xml/module.py
@@ -19,7 +19,8 @@ def handle_module_collect_winnings(user, request):
 	won = request.get("won") == "True"
 	# todo: arcade stats
 	if won:
-		prize = module.select_arcade_prize(user)
+		all_prizes = module.item.moduleguestyields.all()
+		prize = module._get_yield(all_prizes)
 		return {"won": won, "prize": prize}
 	else:
 		return {"won": won}


### PR DESCRIPTION
Looks like #23/#25 both left arcades to be handled later.... now it's done! Thankfully it's just a few lines. Logic is to make sure the normal guest yields don't trigger, and that the module doesn't tear itself down right away (should it???), then calculate the yield based on their probabilities by calling `Module._get_yield`. 